### PR TITLE
feat: switch to basic progress bar to allow non TTY progress

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,0 +1,21 @@
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+name: release-please
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: rust
+          package-name: psdm
+          include-v-in-tag: false
+          token: ${{ secrets.PAT }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,22 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run `cargo publish` - upload to crates.io
-        uses: actions-rs/cargo@v1
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          command: publish
+        run: cargo publish
 
   upload:
     name: ${{ matrix.job.os }} (${{ matrix.job.target }})
@@ -39,26 +33,28 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-musl, use-cross: true }
+          - { os: ubuntu-20.04, target: x86_64-unknown-linux-musl, use-cross: true }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-cross: true }
+          - { os: ubuntu-latest, target: aarch64-unknown-linux-musl, use-cross: true }
+          - { os: ubuntu-latest, target: i686-unknown-linux-musl, use-cross: true }
           - { os: macos-latest, target: x86_64-apple-darwin, use-cross: true }
+          - { os: macos-latest, target: aarch64-apple-darwin, use-cross: true }
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Extract crate information
         shell: bash
         run: |
-          echo "PROJECT_NAME=${{ github.event.repository.name }}" >> $GITHUB_ENV
+          echo "PROJECT_NAME=psdm" >> $GITHUB_ENV
           echo "PROJECT_VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -n1)" >> $GITHUB_ENV
           echo "PROJECT_MAINTAINER=$(sed -n 's/^authors = \["\(.*\)"\]/\1/p' Cargo.toml)" >> $GITHUB_ENV
           echo "PROJECT_HOMEPAGE=$(sed -n 's/^homepage = "\(.*\)"/\1/p' Cargo.toml)" >> $GITHUB_ENV
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          target: ${{ matrix.job.target }}
-          override: true
-          profile: minimal # minimal component installation (ie, no documentation)
+          targets: ${{ matrix.job.target }}
 
       - name: Show version information (Rust, cargo, GCC)
         shell: bash
@@ -69,48 +65,32 @@ jobs:
           rustup default
           cargo -V
           rustc -V
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.job.use-cross }}
-          command: build
-          args: --release --target=${{ matrix.job.target }}
 
-      - name: Strip debug information from executable
-        id: strip
+      - name: Install cross
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Build with cross
+        run: cross build --release --target=${{ matrix.job.target }}
+
+      - name: Set binary name & path
+        id: bin
         shell: bash
         run: |
           # Figure out suffix of binary
           EXE_suffix=""
-          # Figure out what strip tool to use if any
-          STRIP="strip"
+          case ${{ matrix.job.target }} in
+          *-pc-windows-*) EXE_suffix=".exe" ;;
+          esac;
+
           # Setup paths
-          BIN_DIR="${{ env.CICD_INTERMEDIATES_DIR }}/stripped-release-bin/"
-          mkdir -p "${BIN_DIR}"
           BIN_NAME="${{ env.PROJECT_NAME }}${EXE_suffix}"
-          BIN_PATH="${BIN_DIR}/${BIN_NAME}"
-          # Copy the release build binary to the result location
-          cp "target/${{ matrix.job.target }}/release/${BIN_NAME}" "${BIN_DIR}"
-          # Also strip if possible
-          if [ -n "${STRIP}" ]; then
-            "${STRIP}" "${BIN_PATH}"
-          fi
-          # Let subsequent steps know where to find the (stripped) bin
-          echo ::set-output name=BIN_PATH::${BIN_PATH}
-          echo ::set-output name=BIN_NAME::${BIN_NAME}
-      - name: Set testing options
-        id: test-options
-        shell: bash
-        run: |
-          unset CARGO_TEST_OPTIONS
-          unset CARGO_TEST_OPTIONS ; case ${{ matrix.job.target }} in arm-* | aarch64-*) CARGO_TEST_OPTIONS="--bin ${PROJECT_NAME}" ;; esac;
-          echo ::set-output name=CARGO_TEST_OPTIONS::${CARGO_TEST_OPTIONS}
-      - name: Run tests
-        uses: actions-rs/cargo@v1
-        with:
-          use-cross: ${{ matrix.job.use-cross }}
-          command: test
-          args: --target=${{ matrix.job.target }} ${{ steps.test-options.outputs.CARGO_TEST_OPTIONS}}
+          BIN_PATH="target/${{ matrix.job.target }}/release/${BIN_NAME}"
+
+          # Let subsequent steps know where to find the binary
+          echo "BIN_PATH=${BIN_PATH}" >> $GITHUB_OUTPUT
+          echo "BIN_NAME=${BIN_NAME}" >> $GITHUB_OUTPUT
 
       - name: Create tarball
         id: package
@@ -119,14 +99,17 @@ jobs:
           PKG_suffix=".tar.gz" ; case ${{ matrix.job.target }} in *-pc-windows-*) PKG_suffix=".zip" ;; esac;
           PKG_BASENAME=${PROJECT_NAME}-${PROJECT_VERSION}-${{ matrix.job.target }}
           PKG_NAME=${PKG_BASENAME}${PKG_suffix}
-          echo ::set-output name=PKG_NAME::${PKG_NAME}
+          echo "PKG_NAME=${PKG_NAME}" >> $GITHUB_OUTPUT
           PKG_STAGING="${{ env.CICD_INTERMEDIATES_DIR }}/package"
           ARCHIVE_DIR="${PKG_STAGING}/${PKG_BASENAME}/"
           mkdir -p "${ARCHIVE_DIR}"
+          
           # Binary
-          cp "${{ steps.strip.outputs.BIN_PATH }}" "$ARCHIVE_DIR"
+          cp "${{ steps.bin.outputs.BIN_PATH }}" "$ARCHIVE_DIR"
+          
           # README, LICENSE and CHANGELOG files
           cp "README.md" "LICENSE" "CHANGELOG.md" "$ARCHIVE_DIR"
+          
           # base compressed package
           pushd "${PKG_STAGING}/" >/dev/null
           case ${{ matrix.job.target }} in
@@ -134,8 +117,10 @@ jobs:
             *) tar czf "${PKG_NAME}" "${PKG_BASENAME}"/* ;;
           esac;
           popd >/dev/null
+          
           # Let subsequent steps know where to find the compressed package
-          echo ::set-output name=PKG_PATH::"${PKG_STAGING}/${PKG_NAME}"
+          echo "PKG_PATH=${PKG_STAGING}/${PKG_NAME}" >> $GITHUB_OUTPUT
+
       - name: "Artifact upload: tarball"
         uses: actions/upload-artifact@master
         with:
@@ -147,12 +132,14 @@ jobs:
         shell: bash
         run: |
           unset IS_RELEASE ; if [[ $GITHUB_REF =~ ^refs/tags/[0-9].* ]]; then IS_RELEASE='true' ; fi
-          echo ::set-output name=IS_RELEASE::${IS_RELEASE}
+          echo "IS_RELEASE=${IS_RELEASE}" >> $GITHUB_OUTPUT
+
       - name: Publish archives and packages
-        uses: softprops/action-gh-release@59c3b4891632ff9a897f99a91d7bc557467a3a22 # https://github.com/softprops/action-gh-release/issues/139
+        uses: softprops/action-gh-release@v2
         if: steps.is-release.outputs.IS_RELEASE
         with:
           files: |
             ${{ steps.package.outputs.PKG_PATH }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/rust-ci.yaml
+++ b/.github/workflows/rust-ci.yaml
@@ -8,6 +8,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  cog_check_job:
+    runs-on: ubuntu-latest
+    name: check conventional commit compliance
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # pick the pr HEAD instead of the merge commit only if it's a PR, otherwise use the default
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Conventional commit check
+        uses: cocogitto/cocogitto-action@v3
+        with:
+          check-latest-tag-only: true
   check:
     name: Check Rust version ${{ matrix.rust }} on OS ${{ matrix.os }}
     strategy:
@@ -15,19 +29,17 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
         rust:
           - stable
-          - 1.55.0
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -36,9 +48,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
 
   test:
     name: Test Rust version ${{ matrix.rust }} on OS ${{ matrix.os }}
@@ -47,19 +57,19 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
         rust:
           - stable
-          - 1.55.0
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
 
-      - uses: actions/cache@v2
+      - uses: taiki-e/install-action@just
+
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -68,10 +78,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: -v --all-targets --no-fail-fast
+        run: just test
 
   fmt:
     name: Rustfmt
@@ -82,22 +89,16 @@ jobs:
           - stable
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
-
-      - name: Install rustfmt
-        run: rustup component add rustfmt
+          components: rustfmt
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
@@ -108,37 +109,32 @@ jobs:
           - stable
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
+          components: clippy
 
-      - name: Install clippy
-        run: rustup component add clippy
+      - uses: taiki-e/install-action@just
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --all-targets -- -D warnings
+        run: just lint
 
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
+          components: clippy
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry
@@ -146,22 +142,16 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
+      - uses: taiki-e/install-action@v2
         with:
-          version: '0.18.0'
-          timeout: '240'
-          args: ' --bins --tests --follow-exec -- --test-threads 1'
+          tool: cargo-tarpaulin,just
+
+      - name: Run cargo-tarpaulin
+        run: just coverage
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
-
-      - name: Archive code coverage results
-        uses: actions/upload-artifact@v1
-        with:
-          name: code-coverage-report
-          path: cobertura.xml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,7 +78,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e996dc7940838b7ef1096b882e29ec30a3149a3a443cdc8dba19ed382eca1fe2"
 dependencies = [
- "bstr",
+ "bstr 0.2.17",
  "doc-comment",
  "predicates",
  "predicates-core",
@@ -82,10 +131,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "bytes"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "bzip2"
@@ -160,16 +225,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.15.0"
+name = "colorchoice"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+
+[[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
- "terminal_size",
- "winapi",
+ "unicode-width",
+ "windows-sys",
 ]
 
 [[package]]
@@ -183,11 +254,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
 dependencies = [
- "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -217,13 +287,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
-dependencies = [
- "cfg-if",
- "lazy_static",
-]
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "difflib"
@@ -250,16 +316,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
-name = "env_logger"
-version = "0.9.0"
+name = "env_filter"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
+checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
 dependencies = [
- "atty",
- "humantime",
  "log",
  "regex",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b35839ba51819680ba087cd351788c9a3c476841207e0b8cee0b04722343b9"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -324,22 +400,47 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.16.2"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+checksum = "763a5a8f45087d6bcea4222e7b72c291a054edf80e4ef6efd2a4979878c7bea3"
 dependencies = [
  "console",
- "lazy_static",
+ "instant",
  "number_prefix",
+ "portable-atomic",
  "rayon",
- "regex",
+ "unicode-width",
 ]
+
+[[package]]
+name = "instant"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -358,12 +459,9 @@ checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
 
 [[package]]
 name = "log"
-version = "0.4.14"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
-dependencies = [
- "cfg-if",
-]
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lzma-sys"
@@ -387,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -439,43 +537,36 @@ dependencies = [
 
 [[package]]
 name = "noodles-bgzf"
-version = "0.4.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a928a96b98144cb5311fb51f4001ccad62c2c2327c1bb6ff335a3abffa632de"
+checksum = "754f4d28655c5d486e2a62814c5dcc46ad2cee5a2b6cbe91fd765a5ec997f91a"
 dependencies = [
  "byteorder",
+ "bytes",
+ "crossbeam-channel",
  "flate2",
 ]
 
 [[package]]
 name = "noodles-core"
-version = "0.2.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "283a438b6fb47341309c83c17054a27779660eae4382365c8532157d3034b84a"
+checksum = "c5a8c6b020d1205abef2b0fab4463a6c5ecc3c8f4d561ca8b0d1a42323376200"
 dependencies = [
- "noodles-sam",
+ "bstr 1.9.1",
 ]
 
 [[package]]
 name = "noodles-fasta"
-version = "0.3.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd77d148d1d477de3ae1580ac42938f272e7dd48b9491b443983f7e4fbba7d6c"
+checksum = "195e5a37b273b03499d85a83e9101532c02a21c7b9b2d9c11960b6fbfdcd39ad"
 dependencies = [
+ "bstr 1.9.1",
+ "bytes",
  "memchr",
  "noodles-bgzf",
  "noodles-core",
-]
-
-[[package]]
-name = "noodles-sam"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a80fc96a204466efcc0bb841fa6087dfabc59ca02ad69a7dc2474d92058958f"
-dependencies = [
- "bitflags",
- "indexmap",
- "noodles-bgzf",
 ]
 
 [[package]]
@@ -507,26 +598,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
-name = "once_cell"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "os_str_bytes"
@@ -541,6 +616,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,7 +634,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6ce811d0b2e103743eec01db1c50612221f173084ce2f7941053e94b6bb474"
 dependencies = [
  "difflib",
- "itertools",
+ "itertools 0.10.1",
  "predicates-core",
 ]
 
@@ -615,7 +696,7 @@ dependencies = [
  "clap",
  "env_logger",
  "indicatif",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "ndarray",
  "niffler",
@@ -681,27 +762,22 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
- "num_cpus",
 ]
 
 [[package]]
@@ -752,6 +828,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "serde"
+version = "1.0.185"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be9b6f69f1dfd54c3b568ffa45c310d6973a5e5148fd40cf515acaf38cf5bc31"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,16 +874,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "termtree"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,10 +906,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "version_check"
@@ -890,6 +974,79 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ maintenance = { status = "actively-developed" }
 clap = { version = "3.1", features = ["derive"] }
 anyhow = "1"
 niffler = "2.3"
-noodles-fasta = "0.3"
-itertools = "0.10"
-rayon = "1.5"
-indicatif = {version = "0.16", features = ["rayon"]}
+noodles-fasta = "0.40"
+itertools = "0.13"
+rayon = "1.10"
+indicatif = {version = "0.17", features = ["rayon"]}
 ndarray = "0.15"
 log = "0.4"
-env_logger = "0.9"
+env_logger = "0.11.3"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ conda install psdm
 the current directory and show the help menu.
 
 ```shell
-version="0.2.0"
+version="0.3.0"
 OS=$(uname -s)                                                                                                       
 if [ "$OS" = "Linux" ]; then                                                                                         
     triple="x86_64-unknown-linux-musl"                                                                              
@@ -97,7 +97,7 @@ Currently, there are two pre-compiled binaries available:
 An example of downloading one of these binaries using `wget`
 
 ```shell
-$ version="0.2.0"
+$ version="0.3.0"
 $ URL="https://github.com/mbhall88/psdm/releases/download/${version}/psdm-${version}-x86_64-unknown-linux-musl.tar.gz"
 $ wget "$URL" -O - | tar -xzf -
 $ ./psdm --help
@@ -133,7 +133,7 @@ The above will use the latest version. If you want to specify a version then use
 [tag][quay.io] (or commit) like so.
 
 ```shell
-$ VERSION="0.2.0"
+$ VERSION="0.3.0"
 $ URI="docker://quay.io/mbhall88/psdm:${VERSION}"
 ```
 
@@ -284,9 +284,13 @@ s0,s0,0
 
 I'd like to know the progress of the pairwise comparisons
 
-```shell
-$ psdm -P big.aln.fa
-[2599/11476 (23%) comparisons] █████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ [ETA 00:00:28]
+```
+$ psdm -P -t 8 aln.fa
+[2024-06-20T02:50:32Z INFO  psdm] Using 8 thread(s)
+[2024-06-20T02:50:32Z INFO  psdm] Loading first alignment file...
+[2024-06-20T02:50:38Z INFO  psdm] Loaded 200 sequences with length 4411532bp
+[2024-06-20T02:50:38Z INFO  psdm] Calculating 20100 pairwise distances...
+Progress: 50.00% (10050 / 20100)
 ```
 
 Write the matrix to a file please
@@ -297,7 +301,7 @@ $ psdm -o dists.csv aln1.fa
 
 ```
 $ psdm --help
-psdm 0.2.0
+psdm 0.3.0
 Michael Hall <michael@mbh.sh>
 Compute a pairwise SNP distance matrix from one or two alignment(s)
 
@@ -412,7 +416,7 @@ Please also add a succinct description of the contribution in the
   month        = nov,
   year         = 2021,
   publisher    = {Zenodo},
-  version      = {0.2.0},
+  version      = {0.3.0},
   doi          = {10.5281/zenodo.5706784},
   url          = {https://doi.org/10.5281/zenodo.5706785}
 }

--- a/justfile
+++ b/justfile
@@ -1,0 +1,13 @@
+PROJECT := "psdm"
+
+# run clippy to check for linting issues
+lint:
+    cargo clippy --all-features --all-targets -- -D warnings
+
+# run all tests
+test:
+    cargo test -v --all-targets --no-fail-fast
+
+# get coverage with tarpaulin
+coverage:
+    cargo tarpaulin -t 300 -- --test-threads 1

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -18,7 +18,7 @@ fn more_than_two_input_files_fails() -> Result<(), Box<dyn std::error::Error>> {
     file.write_all(text.as_bytes()).unwrap();
     let mut cmd = Command::cargo_bin("psdm").unwrap();
     let err_msg = cmd
-        .args(&[file.path(), file.path(), file.path()])
+        .args([file.path(), file.path(), file.path()])
         .unwrap_err()
         .to_string();
 
@@ -36,7 +36,7 @@ fn trying_to_create_output_in_nonexistent_dir() -> Result<(), Box<dyn std::error
     let p = "foo/bar/aln.fa";
 
     let err_msg = cmd
-        .args(&["-o", p, file.path().to_str().unwrap()])
+        .args(["-o", p, file.path().to_str().unwrap()])
         .unwrap_err()
         .to_string();
 
@@ -51,7 +51,7 @@ fn alignment_is_not_fasta() -> Result<(), Box<dyn std::error::Error>> {
     let mut file = tempfile::Builder::new().suffix(".fa").tempfile().unwrap();
     file.write_all(text.as_bytes()).unwrap();
     let mut cmd = Command::cargo_bin("psdm").unwrap();
-    let err_msg = cmd.args(&[file.path()]).unwrap_err().to_string();
+    let err_msg = cmd.args([file.path()]).unwrap_err().to_string();
 
     assert!(err_msg.contains("Failed to load first alignment"));
 
@@ -64,7 +64,7 @@ fn alignment_seqs_do_not_have_same_length() -> Result<(), Box<dyn std::error::Er
     let mut file = tempfile::Builder::new().suffix(".fa").tempfile().unwrap();
     file.write_all(text.as_bytes()).unwrap();
     let mut cmd = Command::cargo_bin("psdm").unwrap();
-    let err_msg = cmd.args(&[file.path()]).unwrap_err().to_string();
+    let err_msg = cmd.args([file.path()]).unwrap_err().to_string();
 
     assert!(err_msg.contains("sequences must all be the same length"));
 
@@ -80,7 +80,7 @@ fn alignment_files_do_not_have_same_length() -> Result<(), Box<dyn std::error::E
 
     let mut cmd = Command::cargo_bin("psdm").unwrap();
     let err_msg = cmd
-        .args(&[file1.path(), file2.path()])
+        .args([file1.path(), file2.path()])
         .unwrap_err()
         .to_string();
 
@@ -94,7 +94,7 @@ fn intra_alignment_with_defaults() -> Result<(), Box<dyn std::error::Error>> {
     let aln = "tests/cases/aln1.fa";
 
     let mut cmd = Command::cargo_bin("psdm").unwrap();
-    let output = cmd.args(&["-c", aln]).unwrap().stdout;
+    let output = cmd.args(["-c", aln]).unwrap().stdout;
 
     let expected = b",s1,s2,s0\ns1,0,3,3\ns2,3,0,5\ns0,3,5,0\n";
     assert_eq!(output, expected);
@@ -108,7 +108,7 @@ fn intra_alignment_with_ignore_case_ignore_no_characters() -> Result<(), Box<dyn
     let aln = "tests/cases/aln1.fa";
 
     let mut cmd = Command::cargo_bin("psdm").unwrap();
-    let output = cmd.args(&["-e ''", aln]).unwrap().stdout;
+    let output = cmd.args(["-e ''", aln]).unwrap().stdout;
 
     let expected = b",s1,s2,s0\ns1,0,4,1\ns2,4,0,5\ns0,1,5,0\n";
     assert_eq!(output, expected);
@@ -121,7 +121,7 @@ fn intra_alignment_with_use_case_ignore_characters() -> Result<(), Box<dyn std::
     let aln = "tests/cases/aln1.fa";
 
     let mut cmd = Command::cargo_bin("psdm").unwrap();
-    let output = cmd.args(&["-ce n-", aln]).unwrap().stdout;
+    let output = cmd.args(["-ce n-", aln]).unwrap().stdout;
 
     let expected = b",s1,s2,s0\ns1,0,3,3\ns2,3,0,5\ns0,3,5,0\n";
     assert_eq!(output, expected);
@@ -134,7 +134,7 @@ fn intra_alignment_with_ignore_case_ignore_characters() -> Result<(), Box<dyn st
     let aln = "tests/cases/aln1.fa";
 
     let mut cmd = Command::cargo_bin("psdm").unwrap();
-    let output = cmd.args(&["-e aN", aln]).unwrap().stdout;
+    let output = cmd.args(["-e aN", aln]).unwrap().stdout;
 
     let expected = b",s1,s2,s0\ns1,0,2,1\ns2,2,0,3\ns0,1,3,0\n";
     assert_eq!(output, expected);
@@ -148,7 +148,7 @@ fn intra_alignment_with_ignore_case_ignore_characters_sorted(
     let aln = "tests/cases/aln1.fa";
 
     let mut cmd = Command::cargo_bin("psdm").unwrap();
-    let output = cmd.args(&["-s", "-e aN", aln]).unwrap().stdout;
+    let output = cmd.args(["-s", "-e aN", aln]).unwrap().stdout;
 
     let expected = b",s0,s1,s2\ns0,0,1,3\ns1,1,0,2\ns2,3,2,0\n";
     assert_eq!(output, expected);
@@ -161,7 +161,7 @@ fn intra_alignment_with_defaults_long_form() -> Result<(), Box<dyn std::error::E
     let aln = "tests/cases/aln1.fa";
 
     let mut cmd = Command::cargo_bin("psdm").unwrap();
-    let output = cmd.args(&["-cl", aln]).unwrap().stdout;
+    let output = cmd.args(["-cl", aln]).unwrap().stdout;
 
     let expected = b"s1,s1,0
 s1,s2,3
@@ -182,7 +182,7 @@ fn intra_alignment_with_defaults_long_form_sorted() -> Result<(), Box<dyn std::e
     let aln = "tests/cases/aln1.fa";
 
     let mut cmd = Command::cargo_bin("psdm").unwrap();
-    let output = cmd.args(&["-cls", aln]).unwrap().stdout;
+    let output = cmd.args(["-cls", aln]).unwrap().stdout;
 
     let expected = b"s0,s0,0
 s0,s1,3
@@ -204,7 +204,7 @@ fn inter_alignment_with_tab_delim() -> Result<(), Box<dyn std::error::Error>> {
     let aln2 = "tests/cases/aln2.fa.gz";
 
     let mut cmd = Command::cargo_bin("psdm").unwrap();
-    let output = cmd.args(&["-cd '\t'", aln1, aln2]).unwrap().stdout;
+    let output = cmd.args(["-cd '\t'", aln1, aln2]).unwrap().stdout;
 
     let expected = b"\ts1\ts2\ts0\ns2\t6\t6\t5\ns5\t1\t4\t3\n";
     assert_eq!(output, expected);
@@ -217,7 +217,7 @@ fn inter_alignment_in_long_form_sorted() -> Result<(), Box<dyn std::error::Error
     let aln2 = "tests/cases/aln2.fa.gz";
 
     let mut cmd = Command::cargo_bin("psdm").unwrap();
-    let output = cmd.args(&["-lsc", aln1, aln2]).unwrap().stdout;
+    let output = cmd.args(["-lsc", aln1, aln2]).unwrap().stdout;
 
     let expected = b"s0,s2,5\ns0,s5,3\ns1,s2,6\ns1,s5,1\ns2,s2,6\ns2,s5,4\n";
     assert_eq!(output, expected);


### PR DESCRIPTION
The current progress bar does not work if the stderr is being redirected to a file. This makes it impossible to see progress when running on something like a cluster. In addition, indicatif, the library that was used for the progress bar has known overhead problems with parallel iterators, which we have.

With all of this in mind I have moved to a more 'basic' progres bar with minimal bells and whistles to avoid overhead and to work on non TTY.